### PR TITLE
updated endpoint to not take place info object

### DIFF
--- a/src/main/java/com/climatetree/places/controller/PlacesController.java
+++ b/src/main/java/com/climatetree/places/controller/PlacesController.java
@@ -28,8 +28,8 @@ public class PlacesController {
 	NamesService namesService;
 
 	@GetMapping("/places/{placeId}/similar")
-	public List<PlaceDTO> getSimilarPlaces(@PathVariable("placeId") int placeId, @RequestBody PlaceDTO place) {
-		return placesService.getSimilarPlaces(place);
+	public List<PlaceDTO> getSimilarPlaces(@PathVariable("placeId") int placeId) {
+		return placesService.getSimilarPlaces(placeId);
 	}
 
 	@GetMapping("/names/{name}")

--- a/src/main/java/com/climatetree/places/service/PlacesService.java
+++ b/src/main/java/com/climatetree/places/service/PlacesService.java
@@ -19,34 +19,37 @@ public class PlacesService {
 	PlaceRepository placesRepo;
 
 	public PlaceInfo findPlaceById(int placeId) {
-		Optional<PlaceInfo> placesOp =  placesRepo.findById(placeId);
-		return placesOp.isPresent() ? placesOp.get(): null;
+		Optional<PlaceInfo> placesOp = placesRepo.findById(placeId);
+		return placesOp.isPresent() ? placesOp.get() : null;
 	}
-	
+
 	public List<PlaceInfo> findAllPlaces() {
 		List<PlaceInfo> places = new ArrayList<>();
 		placesRepo.findAll().forEach(p -> places.add(p));
 		return places;
 	}
-	
+
 	/**
-	 * Returns places that adhere to all of the following constraints when compared to the given place:
-	 *  1. Between 95% to 150% of the given place's population
-	 *  2. Between 95% to 150% of the given place's population density
-	 *  
+	 * Returns places that adhere to all of the following constraints when compared
+	 * to the given place: 1. Between 95% to 150% of the given place's population 2.
+	 * Between 95% to 150% of the given place's population density
+	 * 
 	 * @param place a PlaceDTO object
 	 * @return a list of PlaceDTO objects that are "similar" to the given PlaceDTO
 	 */
-	public List<PlaceDTO> getSimilarPlaces(PlaceDTO place) {
+	public List<PlaceDTO> getSimilarPlaces(int placeId) {
 		List<PlaceDTO> places = new ArrayList<>();
-		double pop_start = place.getPopulation() * .95;
-		double pop_end = place.getPopulation() * 1.50;
-		double popDensity_start = place.getPopdensity() * .95;
-		double popDensity_end = place.getPopdensity() * 1.50;
-		
-		this.placesRepo.getSimilarPlaces(pop_start, pop_end, popDensity_start, popDensity_end)
-		.forEach(p -> places.add(Mapper.placeInfoToPlaceDTO(p)));
-		
+		Optional<PlaceInfo> placeOpt = placesRepo.findById(placeId);
+		if (placeOpt.isPresent()) {
+			PlaceInfo place = placeOpt.get();
+			double pop_start = place.getPopulation() * .95;
+			double pop_end = place.getPopulation() * 1.50;
+			double popDensity_start = place.getPopdensity() * .95;
+			double popDensity_end = place.getPopdensity() * 1.50;
+
+			this.placesRepo.getSimilarPlaces(pop_start, pop_end, popDensity_start, popDensity_end)
+					.forEach(p -> places.add(Mapper.placeInfoToPlaceDTO(p)));
+		}
 		return places;
 	}
 

--- a/src/test/java/com/climatetree/places/controller/PlacesControllerTest.java
+++ b/src/test/java/com/climatetree/places/controller/PlacesControllerTest.java
@@ -4,6 +4,7 @@ package com.climatetree.places.controller;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -70,7 +71,7 @@ public class PlacesControllerTest {
 		places.add(dto1);
 		places.add(dto2);
 
-		when(placeService.getSimilarPlaces(any(PlaceDTO.class))).thenReturn(places);
+		when(placeService.getSimilarPlaces(anyInt())).thenReturn(places);
 
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);

--- a/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
+++ b/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
@@ -2,11 +2,13 @@ package com.climatetree.places.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +53,9 @@ public class PlacesServiceTest {
 		// Add the object to an ArrayList
 		List<PlaceInfo> our_list = new ArrayList<>();
 		our_list.add(repoParam);
+		
+		// When we call findById on our repo, return the above repoParam we created
+		when(repo.findById(anyInt())).thenReturn(Optional.of(repoParam));
 		
 		// When we call getSimilarPlaces on our repo, return the above list we created
 		when(repo.getSimilarPlaces(anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(our_list);

--- a/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
+++ b/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
@@ -57,7 +57,7 @@ public class PlacesServiceTest {
 		
 		// call the placesService.ggitetSimilarPlaces function
 		PlaceDTO param = new PlaceDTO(0, "", "", 1.0, 2.0, 3.0, 4.0, 5, 6);
-		List<PlaceDTO> places = service.getSimilarPlaces(param);
+		List<PlaceDTO> places = service.getSimilarPlaces(param.getPlaceId());
 		
 		// Assert that our function returned the right information
 		assertThat(places).hasSize(1);


### PR DESCRIPTION
### Change type:
- New feature

### Description:
- This PR makes change to the similar places endpoint by expecting the place id in the request parameter and no request object.

### Trello Card Link:
https://trello.com/c/TBEC8xgJ

### PR Checklist:
- [x] Changes do not introduce new warnings or errors
- [x] Tests were added or modified to cover changes
- [x] All new and existing tests pass

### Steps to Verify Pull Request
- Start the app
- Hit the endpoint "/places/{placeId}/similar"
- Should get similar places for the place with the place Id